### PR TITLE
出退勤編集ページのエラーを修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,9 @@
       "matches": [
         "https://ssl.jobcan.jp/employee/attendance*"
       ],
+      "exclude_matches": [
+        "https://ssl.jobcan.jp/employee/attendance/edit*"
+      ],
       "js": [
         "src/attendance.js"
       ]


### PR DESCRIPTION
## 概要

出退勤編集のページで以下のようなエラーが発生していたため、修正しました。

![image](https://user-images.githubusercontent.com/307352/141211447-7c93c272-86e8-4a62-a7dd-94bf2117901c.png)

## 修正方針

`manifest.json`を修正。
`attendance.js`が発火するページを`exclude_matches`を使い、制限しました。

参考）https://developer.mozilla.org/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts

## テスト

- [x] 出勤簿ページ（/attendance）にて、jsエラーが発生しない
- [x] 出退勤編集のページ（/attendance/edit）にて、jsエラーが発生しない